### PR TITLE
Add links to dockerhub and 64bit upstream issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# docker-alpine-pigpiod
-![Docker Pulls](https://img.shields.io/docker/pulls/zinen2/alpine-pigpiod)
+# docker-alpine-pigpiod [![dockerhub-badge][]][dockerhub]
+
+[dockerhub]:       https://hub.docker.com/r/zinen2/alpine-pigpiod
+[dockerhub-badge]: https://img.shields.io/docker/pulls/zinen2/alpine-pigpiod
 
 Docker image containing [pigpiod](http://abyz.me.uk/rpi/pigpio/pigpiod.html) running on port 8888. 
 Can be used together with [node-red](https://nodered.org/) to access GPIOs on raspberry pi. by installing package [node-red-node-pi-gpiod](https://flows.nodered.org/node/node-red-node-pi-gpiod)
@@ -22,10 +24,12 @@ It should not be necessary to specify the architecture of the board, but just in
 | Raspberry Pi (1, Zero, Zero W) | zinen2/alpine-pigpiod:arm32v6 | :heavy_check_mark: yes, works on rpi1 | 76 |
 | Raspberry Pi 2 | zinen2/alpine-pigpiod:arm32v7 | :black_square_button: no | NA |
 | Raspberry Pi 3 (32bit) | zinen2/alpine-pigpiod:arm32v7 | :heavy_check_mark: yes, works | 76 |
-| Raspberry Pi 3 (64bit) | zinen2/alpine-pigpiod:arm64v8 | :x: yes but don't work | 76 |
+| Raspberry Pi 3 (64bit) | zinen2/alpine-pigpiod:arm64v8 | :x: [yes but don't work][64-issue] | 76 |
 | Raspberry Pi 4 | zinen2/alpine-pigpiod:arm64v8 | :black_square_button: no | NA |
 
 \**If you test it on your hardware, please respond back if it worked.*
+
+[64-issue]: https://github.com/joan2937/pigpio/issues/362
 
 ## Credits
 `start.sh` is a copy from another project and the creator’s repo is [found here](https://github.com/janvda/balena-node-red).


### PR DESCRIPTION
Added a couple of links for quicker navigation to the dockerhub and the upstream 64bit issue.

Readme preview with these changes: https://github.com/2m/docker-alpine-pigpiod/tree/patch-1